### PR TITLE
Changed `destroyed?` to `deleted?` to allow saving destroyed_at value

### DIFF
--- a/app/models/houston/alerts/alert.rb
+++ b/app/models/houston/alerts/alert.rb
@@ -338,7 +338,10 @@ module Houston
         closed_at.present?
       end
 
-      def destroyed?
+      # Rails uses `destroyed?` when checking whether to update/save
+      # a record, so we can't tie it to destroyed_at, or else we'll never
+      # be able to save the destroyed_at field with a value. (-_-;)
+      def deleted?
         destroyed_at.present?
       end
 


### PR DESCRIPTION
### Summary

This was tricky. It seems in recent versions of Rails, the method underlying `save`, `update`, and the like checks if the record is `destroyed?` and returns false if `destroyed?` is true. This means that we would _never_ be able to save a new value for `destroyed_at`, since our custom implementation would always return true, resulting in a failed save. While this change is breaking, it seems necessary to do so, since Houston instances can change their consumption of the model, whereas Rails won't. 😅