### PR TITLE
Only assigned project_id if project_id supplied as a param

### DIFF
--- a/app/controllers/houston/alerts/alerts_controller.rb
+++ b/app/controllers/houston/alerts/alerts_controller.rb
@@ -47,7 +47,7 @@ module Houston
         alert = Alert.with_suppressed.find(params[:id])
         authorize! :update, alert
         attributes = params.permit(:checked_out_by_id, :suppressed).to_h
-        attributes[:project_id] = params[:project_id] if alert.can_change_project?
+        attributes[:project_id] = params[:project_id] if alert.can_change_project? && params.key?(:project_id)
         alert.updated_by = current_user
         if alert.update_attributes(attributes)
           render json: Houston::Alerts::AlertPresenter.new(alert)


### PR DESCRIPTION
### Summary
Whoops! By assigning an alert, it was taken off the board (by clearing its `project_id`). Efficiency! 🙃 